### PR TITLE
feat: added AppBar as a top navigation bar

### DIFF
--- a/client/components/AppBar/AppBar.tsx
+++ b/client/components/AppBar/AppBar.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+
+import Box from '../Box/Box';
+import Button from '../Button/Button';
+
+export default function BasicAppBar() {
+  return (
+    <Box
+      component="span"
+      sx={{ flexGrow: 1 }}
+    >
+      <AppBar position="static">
+        <Toolbar>
+          <Button
+            href="/"
+            color="inherit"
+          >
+            Home
+          </Button>
+          <Button
+            href="/login"
+            color="inherit"
+          >
+            Log In{' '}
+          </Button>
+        </Toolbar>
+      </AppBar>
+    </Box>
+  );
+}

--- a/client/components/LoginForm/LoginForm.tsx
+++ b/client/components/LoginForm/LoginForm.tsx
@@ -25,7 +25,7 @@ export default function LoginForm() {
       component="main"
       maxWidth="xs"
       sx={{
-        marginTop: '20vh',
+        marginTop: '10vh',
       }}
     >
       <Box

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import theme from '../theme/theme';
+import AppBar from '../components/AppBar/AppBar';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -24,6 +25,7 @@ function MyApp({ Component, pageProps }: AppProps) {
           rel="stylesheet"
         />
       </Head>
+      <AppBar />
       <Component {...pageProps} />
     </ThemeProvider>
   );

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -1,31 +1,21 @@
 import type { NextPage } from 'next';
-import Link from 'next/link';
 import Typography from '../components/Typography/Typography';
+import Container from '../components/Container/Container';
 
 const Home: NextPage = () => {
   return (
-    <div>
+    <Container
+      component="main"
+      sx={{ marginTop: '10vh' }}
+    >
       <Typography
         variant="h5"
         component="h1"
         align="center"
       >
-        Hello world dashboard.
+        Dashboard
       </Typography>
-      <Typography
-        variant="body2"
-        component="h2"
-        align="center"
-      >
-        <Link href="/login">
-          <a>Log in</a>
-        </Link>
-        <br />
-        <Link href="/sandbox">
-          <a>Sandbox</a>
-        </Link>
-      </Typography>
-    </div>
+    </Container>
   );
 };
 


### PR DESCRIPTION
- Added navigation bar to top of the page to click between the skeleton pages we have created

### What requires special attention?
 AppBar.tsx - Created the nav bar with AppBar from MaterialUI and used href prop in the buttons for navigation. Is there a better method of routing I should use here? For now I've just gone with something that works and was easy to implement.

_app.tsx - I've placed the <AppBar /> component here so it is fixed across the whole application.

<img width="950" alt="Screenshot 2022-07-27 at 11 04 36" src="https://user-images.githubusercontent.com/59081115/181221127-af7af087-5041-46ed-aa08-5719cfe7c316.png">
<img width="950" alt="Screenshot 2022-07-27 at 11 15 04" src="https://user-images.githubusercontent.com/59081115/181223185-3014b796-e2c4-40d0-88d1-12c0a0ad3aee.png">

