### PR TITLE
Feature/skeleton profile page

### DIFF
--- a/client/components/AppBar/AppBar.tsx
+++ b/client/components/AppBar/AppBar.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+
+import Box from '../Box/Box';
+import Button from '../Button/Button';
+
+export default function BasicAppBar() {
+  return (
+    <Box
+      component="span"
+      sx={{ flexGrow: 1 }}
+    >
+      <AppBar position="static">
+        <Toolbar>
+          <Button
+            href="/"
+            color="inherit"
+          >
+            Home
+          </Button>
+          <Button
+            href="/profile"
+            color="inherit"
+          >
+            Profile
+          </Button>
+          <Button
+            href="/login"
+            color="inherit"
+          >
+            Log In
+          </Button>
+        </Toolbar>
+      </AppBar>
+    </Box>
+  );
+}

--- a/client/components/LoginForm/LoginForm.tsx
+++ b/client/components/LoginForm/LoginForm.tsx
@@ -25,7 +25,7 @@ export default function LoginForm() {
       component="main"
       maxWidth="xs"
       sx={{
-        marginTop: '20vh',
+        marginTop: '10vh',
       }}
     >
       <Box

--- a/client/components/ProfileCard/ProfileCard.tsx
+++ b/client/components/ProfileCard/ProfileCard.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import Card from '../Card/Card/Card';
+import CardActions from '../Card/CardActions/CardActions';
+import CardContent from '../Card/CardContent/CardContent';
+import Button from '../Button/Button';
+import Typography from '../Typography/Typography';
+import Container from '../Container/Container';
+import Avatar from '../Avatar/Avatar';
+import Box from '../Box/Box';
+import Grid from '../Grid/Grid';
+
+interface ProfileCardProps {
+  name: string;
+  email: string;
+  phone: string;
+}
+
+export default function ProfileCard({ name, email, phone }: ProfileCardProps) {
+  return (
+    <>
+      <Container
+        component="main"
+        sx={{
+          marginTop: '10vh',
+          minWidth: '90vw',
+        }}
+      >
+        <Card>
+          <CardContent>
+            <Box
+              component="span"
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                marginBottom: '2rem',
+              }}
+            >
+              <Avatar
+                src=""
+                alt="Default avatar image"
+                sx={{ width: 96, height: 96, marginBottom: '1rem' }}
+              />
+              <Typography
+                gutterBottom
+                variant="h5"
+                component="h1"
+              >
+                {name}
+              </Typography>
+            </Box>
+            <Grid
+              container
+              spacing={2}
+            >
+              <Grid
+                item
+                xs={3}
+              >
+                <Typography
+                  variant="body1"
+                  component="p"
+                >
+                  Full Name:
+                </Typography>
+              </Grid>
+              <Grid
+                item
+                xs={9}
+              >
+                <Typography
+                  variant="body1"
+                  component="p"
+                >
+                  {name}
+                </Typography>
+              </Grid>
+              <Grid
+                item
+                xs={3}
+              >
+                <Typography
+                  variant="body1"
+                  component="p"
+                >
+                  Email Address:
+                </Typography>
+              </Grid>
+              <Grid
+                item
+                xs={9}
+              >
+                <Typography
+                  variant="body1"
+                  component="p"
+                >
+                  {email}
+                </Typography>
+              </Grid>
+              <Grid
+                item
+                xs={3}
+              >
+                <Typography
+                  variant="body1"
+                  component="p"
+                >
+                  Phone Number:
+                </Typography>
+              </Grid>
+              <Grid
+                item
+                xs={9}
+              >
+                <Typography
+                  variant="body1"
+                  component="p"
+                >
+                  {phone}
+                </Typography>
+              </Grid>
+            </Grid>
+          </CardContent>
+          <Box
+            component="span"
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-end',
+            }}
+          >
+            <CardActions>
+              <Button>Edit Profile</Button>
+            </CardActions>
+          </Box>
+        </Card>
+      </Container>
+    </>
+  );
+}

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import theme from '../theme/theme';
+import AppBar from '../components/AppBar/AppBar';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -24,6 +25,7 @@ function MyApp({ Component, pageProps }: AppProps) {
           rel="stylesheet"
         />
       </Head>
+      <AppBar />
       <Component {...pageProps} />
     </ThemeProvider>
   );

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -1,31 +1,21 @@
 import type { NextPage } from 'next';
-import Link from 'next/link';
 import Typography from '../components/Typography/Typography';
+import Container from '../components/Container/Container';
 
 const Home: NextPage = () => {
   return (
-    <div>
+    <Container
+      component="main"
+      sx={{ marginTop: '10vh' }}
+    >
       <Typography
         variant="h5"
         component="h1"
         align="center"
       >
-        Hello world dashboard.
+        Dashboard
       </Typography>
-      <Typography
-        variant="body2"
-        component="h2"
-        align="center"
-      >
-        <Link href="/login">
-          <a>Log in</a>
-        </Link>
-        <br />
-        <Link href="/sandbox">
-          <a>Sandbox</a>
-        </Link>
-      </Typography>
-    </div>
+    </Container>
   );
 };
 

--- a/client/pages/profile.tsx
+++ b/client/pages/profile.tsx
@@ -1,0 +1,18 @@
+import type { NextPage } from 'next';
+import ProfileCard from '../components/ProfileCard/ProfileCard';
+
+const Profile: NextPage = () => {
+  const DUMMY_DATA = {
+    name: 'John Smith',
+    email: 'johnsmith@gmail.com',
+    phone: '+44 7987654321',
+  };
+
+  return (
+    <>
+      <ProfileCard {...DUMMY_DATA}></ProfileCard>
+    </>
+  );
+};
+
+export default Profile;


### PR DESCRIPTION
- Added basic skeleton for the profile page as a visual place holder
- Added navigation bar to top of the page to click between the skeleton pages we have created

### What requires special attention?
ProfileCard.tsx, profile.tsx - Created basic card component which takes the user's name, email and phone number as props and displays them on the profile page. This page is purely a visual placeholder for now, styling and functionality will be added later.

AppBar.tsx - Created the nav bar with AppBar from MaterialUI and used href prop in the buttons for navigation. Is there a better method for routing that I should use here? For now I've just gone with something that works and was easy to implement.

_app.tsx - I've placed the AppBar component here so it is fixed across the whole application.

<img width="951" alt="Screenshot 2022-07-27 at 11 40 12" src="https://user-images.githubusercontent.com/59081115/181227935-a6dcec02-5282-41e9-a5ab-2e15e248b557.png">

<img width="952" alt="Screenshot 2022-07-27 at 11 40 31" src="https://user-images.githubusercontent.com/59081115/181227962-bbb92d08-2ba6-4faa-bc00-9a11c92a0620.png">

<img width="951" alt="Screenshot 2022-07-27 at 11 40 41" src="https://user-images.githubusercontent.com/59081115/181227982-0969b2ee-bd63-4ec6-918f-81577435e752.png">

