### PR TITLE
feat: added routing with next.js Link component using an adapter for usage with MUI

### DIFF
--- a/client/components/AppBar/AppBar.tsx
+++ b/client/components/AppBar/AppBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
-
+import Link from '../Link/Link';
 import Box from '../Box/Box';
 import Button from '../Button/Button';
 
@@ -16,18 +16,24 @@ export default function BasicAppBar() {
           <Button
             href="/"
             color="inherit"
+            component={Link}
+            noLinkStyle
           >
             Home
           </Button>
           <Button
             href="/profile"
             color="inherit"
+            component={Link}
+            noLinkStyle
           >
             Profile
           </Button>
           <Button
             href="/login"
             color="inherit"
+            component={Link}
+            noLinkStyle
           >
             Log In
           </Button>

--- a/client/components/Button/Button.tsx
+++ b/client/components/Button/Button.tsx
@@ -13,6 +13,8 @@ export default function Button({
   onClick,
   href,
   children,
+  component,
+  noLinkStyle,
 }: ButtonProps) {
   return (
     <MUIButton
@@ -24,6 +26,8 @@ export default function Button({
       sx={sx}
       onClick={onClick}
       href={href}
+      component={component}
+      noLinkStyle={noLinkStyle}
     >
       {children}
     </MUIButton>

--- a/client/components/Button/Button.types.ts
+++ b/client/components/Button/Button.types.ts
@@ -38,4 +38,10 @@ export default interface ButtonProps {
 
   /** The content of the component, e.g its text label */
   children?: React.ReactNode;
+
+  /** The component used for the root node. Should be either a string to use a HTML element or a component. Using relaxed type definition here to allow for {Link} - use sensibly. */
+  component?: any;
+
+  /** Relates to styling of Link component from Next.js  */
+  noLinkStyle?: boolean;
 }

--- a/client/components/Link/Link.tsx
+++ b/client/components/Link/Link.tsx
@@ -1,0 +1,144 @@
+// Taken from MUI example for integration of routing with Next.js: https://mui.com/material-ui/guides/routing/#next-js.
+
+// This specific file comes from: https://codesandbox.io/s/github/mui/material-ui/tree/master/examples/nextjs-with-typescript?file=/src/Link.tsx:0-2879
+
+import * as React from 'react';
+import clsx from 'clsx';
+import { useRouter } from 'next/router';
+import NextLink, { LinkProps as NextLinkProps } from 'next/link';
+import MuiLink, { LinkProps as MuiLinkProps } from '@mui/material/Link';
+import { styled } from '@mui/material/styles';
+
+// Add support for the sx prop for consistency with the other branches.
+const Anchor = styled('a')({});
+
+interface NextLinkComposedProps
+  extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
+    Omit<NextLinkProps, 'href' | 'as' | 'onClick' | 'onMouseEnter'> {
+  to: NextLinkProps['href'];
+  linkAs?: NextLinkProps['as'];
+}
+
+export const NextLinkComposed = React.forwardRef<
+  HTMLAnchorElement,
+  NextLinkComposedProps
+>(function NextLinkComposed(props, ref) {
+  const { to, linkAs, replace, scroll, shallow, prefetch, locale, ...other } =
+    props;
+
+  return (
+    <NextLink
+      href={to}
+      prefetch={prefetch}
+      as={linkAs}
+      replace={replace}
+      scroll={scroll}
+      shallow={shallow}
+      passHref
+      locale={locale}
+    >
+      <Anchor
+        ref={ref}
+        {...other}
+      />
+    </NextLink>
+  );
+});
+
+export type LinkProps = {
+  activeClassName?: string;
+  as?: NextLinkProps['as'];
+  href: NextLinkProps['href'];
+  linkAs?: NextLinkProps['as']; // Useful when the as prop is shallow by styled().
+  noLinkStyle?: boolean;
+} & Omit<NextLinkComposedProps, 'to' | 'linkAs' | 'href'> &
+  Omit<MuiLinkProps, 'href'>;
+
+// A styled version of the Next.js Link component:
+// https://nextjs.org/docs/api-reference/next/link
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+  props,
+  ref,
+) {
+  const {
+    activeClassName = 'active',
+    as,
+    className: classNameProps,
+    href,
+    linkAs: linkAsProp,
+    locale,
+    noLinkStyle,
+    prefetch,
+    replace,
+    role, // Link don't have roles.
+    scroll,
+    shallow,
+    ...other
+  } = props;
+
+  const router = useRouter();
+  const pathname = typeof href === 'string' ? href : href.pathname;
+  const className = clsx(classNameProps, {
+    [activeClassName]: router.pathname === pathname && activeClassName,
+  });
+
+  const isExternal =
+    typeof href === 'string' &&
+    (href.indexOf('http') === 0 || href.indexOf('mailto:') === 0);
+
+  if (isExternal) {
+    if (noLinkStyle) {
+      return (
+        <Anchor
+          className={className}
+          href={href}
+          ref={ref}
+          {...other}
+        />
+      );
+    }
+
+    return (
+      <MuiLink
+        className={className}
+        href={href}
+        ref={ref}
+        {...other}
+      />
+    );
+  }
+
+  const linkAs = linkAsProp || as;
+  const nextjsProps = {
+    to: href,
+    linkAs,
+    replace,
+    scroll,
+    shallow,
+    prefetch,
+    locale,
+  };
+
+  if (noLinkStyle) {
+    return (
+      <NextLinkComposed
+        className={className}
+        ref={ref}
+        {...nextjsProps}
+        {...other}
+      />
+    );
+  }
+
+  return (
+    <MuiLink
+      component={NextLinkComposed}
+      className={className}
+      ref={ref}
+      {...nextjsProps}
+      {...other}
+    />
+  );
+});
+
+export default Link;


### PR DESCRIPTION
- In Link.tsx, imported Link component from Next.js and set up an adapter for usage with MUI library. The adapter was taken from this [example folder](https://github.com/mui/material-ui/blob/02a470741ec285cb5228c29404631488237d5701/examples/nextjs-with-typescript/src/Link.tsx).
- Used this Link component in AppBar.tsx to provide client-side navigation between pages
- Added the necessary props to Button component